### PR TITLE
Use isFillable method from Eloquent model to clean unfillable fields

### DIFF
--- a/src/EloquentRepository.php
+++ b/src/EloquentRepository.php
@@ -306,14 +306,11 @@ abstract class EloquentRepository implements RepositoryInterface
      */
     protected function cleanUnfillableFields( array $data )
     {
-        $fillableFields = $this->model->getFillable();
-        
-        foreach( $data as $key => $value )
-        {
-            if ( !in_array( $key, $fillableFields ) ) unset( $data[ $key ] );
-        }
-        
-        return $data;
+        $model = $this->model;
+
+        return array_filter($data, function ($key) use ($model) {
+            return $model->isFillable($key);
+        }, ARRAY_FILTER_USE_KEY);
     }
     
     /**


### PR DESCRIPTION
The Eloquent Model exposes the `isFillable` method through the GuardsAttributes concern, using this method allows using only the guarded array without needing to explicitly set each fillable attribute.